### PR TITLE
fix: serialize exceptions as structured data instead of PHP objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+.PHONY: install docker-up test coverage lint lint-fix analyse check hooks
+
+# If tsqm-php-cli container is running — execute inside it, otherwise — locally
+DOCKER_EXEC := $(shell docker inspect -f '{{.State.Running}}' tsqm-php-cli 2>/dev/null | grep -q true && echo 'docker exec tsqm-php-cli')
+
+# Start docker services
+docker-up:
+	docker compose up
+
+# Install dependencies and git hooks
+install:
+	$(DOCKER_EXEC) composer install && $(MAKE) hooks
+
+# Run tests (PHPUnit)
+test:
+	$(DOCKER_EXEC) composer test
+
+# Run tests with coverage
+coverage:
+	$(DOCKER_EXEC) composer coverage
+
+# Linter (php-cs-fixer, dry-run)
+lint:
+	$(DOCKER_EXEC) composer lint
+
+# Autoformat (php-cs-fixer)
+lint-fix:
+	$(DOCKER_EXEC) composer lint-fix
+
+# Static analysis (PHPStan)
+analyse:
+	$(DOCKER_EXEC) composer analyse
+
+# Tests + lint + analyse
+check:
+	$(DOCKER_EXEC) composer check
+
+# Install git hooks
+hooks:
+	$(DOCKER_EXEC) composer hooks

--- a/src/Helpers/SerializationHelper.php
+++ b/src/Helpers/SerializationHelper.php
@@ -101,6 +101,7 @@ class SerializationHelper
         return $error;
     }
 
+    /** @param ReflectionClass<Exception> $ref */
     private static function setExceptionProperty(ReflectionClass $ref, Exception $error, string $name, mixed $value): void
     {
         if ($ref->hasProperty($name)) {

--- a/src/Helpers/SerializationHelper.php
+++ b/src/Helpers/SerializationHelper.php
@@ -4,7 +4,7 @@ namespace Tsqm\Helpers;
 
 use __PHP_Incomplete_Class;
 use Exception;
-use ReflectionObject;
+use ReflectionClass;
 use Tsqm\Errors\SerializationError;
 
 class SerializationHelper
@@ -58,43 +58,55 @@ class SerializationHelper
 
     public static function serializeError(Exception $error): string
     {
-        $reflection = new ReflectionObject($error);
-
-        // Traverse up the inheritance chain to find the 'trace' property
-        while (!$reflection->hasProperty('trace') && $reflection->getParentClass()) {
-            $reflection = $reflection->getParentClass();
-        }
-
-        if ($reflection->hasProperty('trace')) {
-            $traceProp = $reflection->getProperty('trace');
-            $traceProp->setAccessible(true);
-            $traceProp->setValue($error, array_slice($error->getTrace(), 0, self::MAX_TRACE_LENGTH));
-        }
-
-        // Traverse up the inheritance chain to find the 'previous' property
-        $reflection = new ReflectionObject($error);
-        while (!$reflection->hasProperty('previous') && $reflection->getParentClass()) {
-            $reflection = $reflection->getParentClass();
-        }
-
-        if ($reflection->hasProperty('previous')) {
-            $previousProp = $reflection->getProperty('previous');
-            $previousProp->setAccessible(true);
-            $previousProp->setValue($error, null);
-        }
-
-        return self::serialize($error);
+        $data = [
+            'class' => get_class($error),
+            'message' => $error->getMessage(),
+            'code' => $error->getCode(),
+            'file' => $error->getFile(),
+            'line' => $error->getLine(),
+            'trace' => array_slice($error->getTrace(), 0, self::MAX_TRACE_LENGTH),
+        ];
+        return self::serialize($data);
     }
 
     public static function unserializeError(string $value): Exception
     {
-        $error = self::unserialize($value);
-        if (is_array($error)) { // Old serialization format
-            return new $error['class']($error['message']);
-        } elseif ($error instanceof Exception) {
-            return $error;
-        } else {
-            throw new SerializationError("Invalid error class");
+        $data = self::unserialize($value);
+
+        // Backward compatibility: old format stored serialized Exception objects
+        if ($data instanceof Exception) {
+            return $data;
+        }
+
+        if (!is_array($data) || !isset($data['class'])) {
+            throw new SerializationError("Invalid error format");
+        }
+
+        $class = $data['class'];
+        if (!class_exists($class) || !is_a($class, Exception::class, true)) {
+            $class = Exception::class;
+        }
+
+        $ref = new ReflectionClass($class);
+        /** @var Exception $error */
+        $error = $ref->newInstanceWithoutConstructor();
+
+        foreach (['message', 'code', 'file', 'line', 'trace'] as $prop) {
+            if (!array_key_exists($prop, $data)) {
+                continue;
+            }
+            self::setExceptionProperty($ref, $error, $prop, $data[$prop]);
+        }
+
+        return $error;
+    }
+
+    private static function setExceptionProperty(ReflectionClass $ref, Exception $error, string $name, mixed $value): void
+    {
+        if ($ref->hasProperty($name)) {
+            $prop = $ref->getProperty($name);
+            $prop->setAccessible(true);
+            $prop->setValue($error, $value);
         }
     }
 }

--- a/src/PersistedTask.php
+++ b/src/PersistedTask.php
@@ -365,7 +365,7 @@ class PersistedTask implements JsonSerializable
             'error' => $this->error ? [
                 'class' => get_class($this->error),
                 'message' => $this->error->getMessage(),
-                'code' => $this->error->getCode() ?? null, // @phpstan-ignore nullCoalesce.expr
+                'code' => $this->error->getCode(),
             ] : null,
             'retry_policy' => $this->retryPolicy,
             'retried' => $this->retried,

--- a/tests/SerializationTest.php
+++ b/tests/SerializationTest.php
@@ -5,11 +5,11 @@ namespace Tests;
 use DateTime;
 use Exception;
 use PDOException;
+use Examples\Greeter\GreeterError;
 use Tsqm\Errors\SerializationError;
 use Tsqm\Helpers\SerializationHelper;
 use Tsqm\Helpers\UuidHelper;
 use Tsqm\PersistedTask;
-use Tsqm\Task;
 use Tsqm\TaskRepository;
 
 class SerializationTest extends TestCase
@@ -45,6 +45,7 @@ class SerializationTest extends TestCase
             $repository->updateTask($ptask);
             $this->assertEquals($expected, $ptask->getError()->getCode(), "Failed with code '$code'");
             $ptask = $repository->getTask($taskId);
+            $this->assertInstanceOf(PDOException::class, $ptask->getError(), "Failed instanceof with code '$code'");
             $this->assertEquals($expected, $ptask->getError()->getCode(), "Failed with code '$code'");
         }
 
@@ -98,5 +99,29 @@ class SerializationTest extends TestCase
         $unserialized = SerializationHelper::unserializeError($serialized);
 
         $this->assertNull($unserialized->getPrevious(), "Previous exception is not null after serialization");
+    }
+
+    public function testErrorInstanceOfPreservedAfterRoundtrip(): void
+    {
+        $error = new GreeterError("Greet failed", 42);
+
+        $serialized = SerializationHelper::serializeError($error);
+        $unserialized = SerializationHelper::unserializeError($serialized);
+
+        $this->assertInstanceOf(GreeterError::class, $unserialized);
+        $this->assertEquals("Greet failed", $unserialized->getMessage());
+        $this->assertEquals(42, $unserialized->getCode());
+    }
+
+    public function testPdoExceptionInstanceOfPreservedAfterRoundtrip(): void
+    {
+        $error = new PDOException("Connection failed", 123);
+
+        $serialized = SerializationHelper::serializeError($error);
+        $unserialized = SerializationHelper::unserializeError($serialized);
+
+        $this->assertInstanceOf(PDOException::class, $unserialized);
+        $this->assertEquals("Connection failed", $unserialized->getMessage());
+        $this->assertEquals(123, $unserialized->getCode());
     }
 }

--- a/tests/TaskFlowTest.php
+++ b/tests/TaskFlowTest.php
@@ -155,6 +155,7 @@ class TaskFlowTest extends TestCase
         $now = new DateTime();
 
         $this->assertDateEquals($task->getFinishedAt(), $now);
+        $this->assertInstanceOf(GreeterError::class, $task->getError());
         $this->assertEquals(new GreeterError("Greet John Doe failed", 1717414866), $task->getError());
         $this->assertNull($task->getResult());
     }
@@ -235,15 +236,17 @@ class TaskFlowTest extends TestCase
 
         // Initial failed run
         $task = $this->tsqm->run($task);
+        $this->assertInstanceOf(GreeterError::class, $task->getError());
         $this->assertEquals(new GreeterError("Greet failed", 1700403919), $task->getError());
         $this->assertNull($task->getFinishedAt());
         $this->assertNull($task->getResult());
         $this->assertEquals(0, $task->getRetried());
 
-        // Two failed retries
+        // Two failed retries (error deserialized from DB)
         for ($i = 0; $i < 2; $i++) {
             $task = $this->tsqm->get($task->getRootId());
             $task = $this->tsqm->run($task);
+            $this->assertInstanceOf(GreeterError::class, $task->getError(), "step $i");
             $this->assertEquals(new GreeterError("Greet failed", 1700403919), $task->getError(), "step $i");
             $this->assertNull($task->getFinishedAt(), "step $i");
             $this->assertNull($task->getResult(), "step $i");


### PR DESCRIPTION
## Changes

- Serialize exceptions as structured arrays (class, message, code, file, line, trace) instead of raw PHP objects via `serialize()`
- Reconstruct exceptions on deserialization using `ReflectionClass::newInstanceWithoutConstructor()` + property injection, preserving `instanceof` checks
- Fix `Undefined property: PDOException::$code` caused by PHP's `unserialize()` corrupting PDOException internals (php-src#9529)
- Remove `?? null` workaround in `PersistedTask::jsonSerialize()` — no longer needed since reconstructed exceptions have properly initialized properties
- Backward compatible: old serialized Exception objects in the DB are still handled

## Attention

- Exceptions with custom properties beyond the standard set (message, code, file, line, trace) will lose those properties during serialization — this is intentional trade-off for robustness
- `previous` exception chain is no longer preserved (same as before)
- Old DB rows with PHP-serialized Exception objects will still deserialize correctly via the backward compat path

## Testing

- [ ] PDOException with string SQLSTATE codes survives serialize/deserialize roundtrip without warnings
- [ ] Standard exceptions preserve class, message, code, file, line, trace after roundtrip
- [ ] `instanceof` checks work on deserialized exceptions (e.g. `catch (PDOException)`)
- [ ] Old serialized format (raw Exception objects) still deserializes correctly
- [ ] Stack trace truncation to 64 frames still works