### PR TITLE
tech: migrate from DateTime to Carbon CarbonImmutable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "ext-json": "*",
     "ext-pcntl": "*",
     "psr/log": "^3.0",
-    "psr/container": "^2.0"
+    "psr/container": "^2.0",
+    "nesbot/carbon": "^3.11"
   },
   "require-dev": {
     "monolog/monolog": "^3.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,230 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06bc9e68a135d06436efbbc88cc7a78e",
+    "content-hash": "34dd6fb7b17eaf48401e6d167e151b3c",
     "packages": [
+        {
+            "name": "carbonphp/carbon-doctrine-types",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CarbonPHP/carbon-doctrine-types.git",
+                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon-doctrine-types/zipball/18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
+                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/dbal": "<4.0.0 || >=5.0.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^4.0.0",
+                "nesbot/carbon": "^2.71.0 || ^3.0.0",
+                "phpunit/phpunit": "^10.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\Doctrine\\": "src/Carbon/Doctrine/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KyleKatarn",
+                    "email": "kylekatarnls@gmail.com"
+                }
+            ],
+            "description": "Types to use Carbon in Doctrine",
+            "keywords": [
+                "carbon",
+                "date",
+                "datetime",
+                "doctrine",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/CarbonPHP/carbon-doctrine-types/issues",
+                "source": "https://github.com/CarbonPHP/carbon-doctrine-types/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "nesbot/carbon",
+            "version": "3.11.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CarbonPHP/carbon.git",
+                "reference": "6a7e652845bb018c668220c2a545aded8594fbbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/6a7e652845bb018c668220c2a545aded8594fbbf",
+                "reference": "6a7e652845bb018c668220c2a545aded8594fbbf",
+                "shasum": ""
+            },
+            "require": {
+                "carbonphp/carbon-doctrine-types": "<100.0",
+                "ext-json": "*",
+                "php": "^8.1",
+                "psr/clock": "^1.0",
+                "symfony/clock": "^6.3.12 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/translation": "^4.4.18 || ^5.2.1 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.6.3 || ^4.0",
+                "doctrine/orm": "^2.15.2 || ^3.0",
+                "friendsofphp/php-cs-fixer": "^v3.87.1",
+                "kylekatarnls/multi-tester": "^2.5.3",
+                "phpmd/phpmd": "^2.15.0",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.22",
+                "phpunit/phpunit": "^10.5.53",
+                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0.0"
+            },
+            "bin": [
+                "bin/carbon"
+            ],
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Carbon\\Laravel\\ServiceProvider"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev",
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\": "src/Carbon/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Nesbitt",
+                    "email": "brian@nesbot.com",
+                    "homepage": "https://markido.com"
+                },
+                {
+                    "name": "kylekatarnls",
+                    "homepage": "https://github.com/kylekatarnls"
+                }
+            ],
+            "description": "An API extension for DateTime that supports 281 different languages.",
+            "homepage": "https://carbonphp.github.io/carbon/",
+            "keywords": [
+                "date",
+                "datetime",
+                "time"
+            ],
+            "support": {
+                "docs": "https://carbonphp.github.io/carbon/guide/getting-started/introduction.html",
+                "issues": "https://github.com/CarbonPHP/carbon/issues",
+                "source": "https://github.com/CarbonPHP/carbon"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon#sponsor",
+                    "type": "opencollective"
+                },
+                {
+                    "url": "https://tidelift.com/subscription/pkg/packagist-nesbot-carbon?utm_source=packagist-nesbot-carbon&utm_medium=referral&utm_campaign=readme",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-11T17:23:39+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
+        },
         {
             "name": "psr/container",
             "version": "2.0.2",
@@ -108,6 +330,498 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "symfony/clock",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/clock.git",
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/674fa3b98e21531dd040e613479f5f6fa8f32111",
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/clock": "^1.0",
+                "symfony/polyfill-php83": "^1.28"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/now.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Clock\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Decouples applications from the system clock",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clock",
+                "psr20",
+                "time"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/clock/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-23T08:48:59+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-08T02:45:35+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "33600f8489485425bfcddd0d983391038d3422e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/33600f8489485425bfcddd0d983391038d3422e7",
+                "reference": "33600f8489485425bfcddd0d983391038d3422e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^2.5.3|^3.3"
+            },
+            "conflict": {
+                "nikic/php-parser": "<5.0",
+                "symfony/config": "<6.4",
+                "symfony/console": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<6.4",
+                "symfony/service-contracts": "<2.5",
+                "symfony/twig-bundle": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "provide": {
+                "symfony/translation-implementation": "2.3|3.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^5.0",
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/http-client-contracts": "^2.5|^3.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/polyfill-intl-icu": "^1.21",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to internationalize your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/translation/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/translation-contracts",
+            "version": "v3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "65a8bc82080447fae78373aa10f8d13b38338977"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/65a8bc82080447fae78373aa10f8d13b38338977",
+                "reference": "65a8bc82080447fae78373aa10f8d13b38338977",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T13:41:35+00:00"
         }
     ],
     "packages-dev": [
@@ -3497,73 +4211,6 @@
             "time": "2026-01-13T11:36:38+00:00"
         },
         {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:21:43+00:00"
-        },
-        {
             "name": "symfony/event-dispatcher",
             "version": "v7.4.4",
             "source": {
@@ -4182,91 +4829,6 @@
                 }
             ],
             "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-mbstring": "*"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "symfony/polyfill-php80",

--- a/examples/Greeter/Greeting.php
+++ b/examples/Greeter/Greeting.php
@@ -2,12 +2,12 @@
 
 namespace Examples\Greeter;
 
-use DateTime;
+use Carbon\CarbonImmutable;
 use JsonSerializable;
 
 class Greeting implements JsonSerializable
 {
-    private DateTime $createdAt;
+    private CarbonImmutable $createdAt;
     private string $text;
     private bool $purchased = false;
     private bool $sent = false;
@@ -15,11 +15,11 @@ class Greeting implements JsonSerializable
 
     public function __construct(string $text)
     {
-        $this->createdAt = new DateTime();
+        $this->createdAt = CarbonImmutable::now();
         $this->text = $text;
     }
 
-    public function getCreatedAt(): DateTime
+    public function getCreatedAt(): CarbonImmutable
     {
         return $this->createdAt;
     }

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -2,4 +2,4 @@
 
 set -e
 
-composer check
+make check

--- a/src/PersistedTask.php
+++ b/src/PersistedTask.php
@@ -2,7 +2,8 @@
 
 namespace Tsqm;
 
-use DateTime;
+use Carbon\CarbonImmutable;
+use DateTimeInterface;
 use Exception;
 use JsonSerializable;
 use Tsqm\Errors\InvalidTask;
@@ -19,15 +20,15 @@ class PersistedTask implements JsonSerializable
 
     private ?string $rootId = null;
 
-    private ?DateTime $createdAt = null;
+    private ?CarbonImmutable $createdAt = null;
 
-    private ?DateTime $scheduledFor = null;
+    private ?CarbonImmutable $scheduledFor = null;
 
     private ?string $waitInterval = null;
 
-    private ?DateTime $startedAt = null;
+    private ?CarbonImmutable $startedAt = null;
 
-    private ?DateTime $finishedAt = null;
+    private ?CarbonImmutable $finishedAt = null;
 
     private ?string $name = null;
 
@@ -126,9 +127,9 @@ class PersistedTask implements JsonSerializable
         return $this->getId() === $this->getRootId();
     }
 
-    public function setCreatedAt(?DateTime $createdAt): self
+    public function setCreatedAt(?DateTimeInterface $createdAt): self
     {
-        $this->createdAt = $createdAt;
+        $this->createdAt = $createdAt ? CarbonImmutable::instance($createdAt) : null;
         return $this;
     }
 
@@ -137,7 +138,7 @@ class PersistedTask implements JsonSerializable
         return !is_null($this->createdAt);
     }
 
-    public function getCreatedAt(): ?DateTime
+    public function getCreatedAt(): ?DateTimeInterface
     {
         if (!$this->isCreated()) {
             throw new InvalidTask("Task was not created yet");
@@ -145,9 +146,9 @@ class PersistedTask implements JsonSerializable
         return $this->createdAt;
     }
 
-    public function setScheduledFor(?DateTime $scheduledFor): self
+    public function setScheduledFor(?DateTimeInterface $scheduledFor): self
     {
-        $this->scheduledFor = $scheduledFor;
+        $this->scheduledFor = $scheduledFor ? CarbonImmutable::instance($scheduledFor) : null;
         return $this;
     }
 
@@ -156,7 +157,7 @@ class PersistedTask implements JsonSerializable
         return !is_null($this->scheduledFor);
     }
 
-    public function getScheduledFor(): ?DateTime
+    public function getScheduledFor(): ?DateTimeInterface
     {
         if (!$this->isScheduled()) {
             throw new InvalidTask("Task was not scheduled yet");
@@ -180,9 +181,9 @@ class PersistedTask implements JsonSerializable
         return $this->waitInterval;
     }
 
-    public function setStartedAt(?DateTime $startedAt): self
+    public function setStartedAt(?DateTimeInterface $startedAt): self
     {
-        $this->startedAt = $startedAt;
+        $this->startedAt = $startedAt ? CarbonImmutable::instance($startedAt) : null;
         return $this;
     }
 
@@ -191,14 +192,14 @@ class PersistedTask implements JsonSerializable
         return !is_null($this->startedAt);
     }
 
-    public function getStartedAt(): ?DateTime
+    public function getStartedAt(): ?DateTimeInterface
     {
         return $this->startedAt;
     }
 
-    public function setFinishedAt(?DateTime $finishedAt): self
+    public function setFinishedAt(?DateTimeInterface $finishedAt): self
     {
-        $this->finishedAt = $finishedAt;
+        $this->finishedAt = $finishedAt ? CarbonImmutable::instance($finishedAt) : null;
         return $this;
     }
 
@@ -207,7 +208,7 @@ class PersistedTask implements JsonSerializable
         return !is_null($this->finishedAt);
     }
 
-    public function getFinishedAt(): ?DateTime
+    public function getFinishedAt(): ?DateTimeInterface
     {
         return $this->finishedAt;
     }

--- a/src/Queue/NullQueue.php
+++ b/src/Queue/NullQueue.php
@@ -2,11 +2,11 @@
 
 namespace Tsqm\Queue;
 
-use DateTime;
+use DateTimeInterface;
 
 class NullQueue implements QueueInterface
 {
-    public function enqueue(string $taskName, string $taskId, DateTime $scheduledFor): void
+    public function enqueue(string $taskName, string $taskId, DateTimeInterface $scheduledFor): void
     {
         // Do nothing
     }

--- a/src/Queue/QueueInterface.php
+++ b/src/Queue/QueueInterface.php
@@ -2,7 +2,7 @@
 
 namespace Tsqm\Queue;
 
-use DateTime;
+use DateTimeInterface;
 use Tsqm\Task;
 
 interface QueueInterface
@@ -10,10 +10,10 @@ interface QueueInterface
     /**
      * @param string $taskName
      * @param string $taskId
-     * @param DateTime $scheduledFor
+     * @param DateTimeInterface $scheduledFor
      * @return void
      */
-    public function enqueue(string $taskName, string $taskId, DateTime $scheduledFor): void;
+    public function enqueue(string $taskName, string $taskId, DateTimeInterface $scheduledFor): void;
 
     /**
      * @param string $taskName

--- a/src/RetryPolicy.php
+++ b/src/RetryPolicy.php
@@ -2,7 +2,8 @@
 
 namespace Tsqm;
 
-use DateTime;
+use Carbon\CarbonImmutable;
+use DateTimeInterface;
 use JsonSerializable;
 use Tsqm\Errors\InvalidRetryPolicy;
 
@@ -33,23 +34,16 @@ class RetryPolicy implements JsonSerializable
 
     /**
      * Set the minimum time between retries in milliseconds
-     * @param int|string $minInterval — miliseconds or a string that can be parsed by DateTime::modify
+     * @param int|string $minInterval — milliseconds or a string that can be parsed by CarbonImmutable::modify
      * @return RetryPolicy
      */
     public function setMinInterval($minInterval): self
     {
         if (is_string($minInterval)) {
-            $nowMicrotime = explode(' ', microtime());
-            $nowMicroseconds = floatval($nowMicrotime[0]) * 1000000;
-            $nowSeconds = $nowMicrotime[1];
-            $nowDt = DateTime::createFromFormat('U.u', "$nowSeconds.$nowMicroseconds");
-            if ($nowDt === false) {
-                throw new InvalidRetryPolicy("Invalid now value: $nowSeconds.$nowMicroseconds");
-            }
-
-            $now = (float) $nowDt->format('U.u');
-            $mod = (float) $nowDt->modify($minInterval)->format('U.u');
-            $this->minInterval = (int) round(($mod - $now) * 1000);
+            $now = CarbonImmutable::now();
+            $nowTs = (float) $now->format('U.u');
+            $modTs = (float) $now->modify($minInterval)->format('U.u');
+            $this->minInterval = (int) round(($modTs - $nowTs) * 1000);
 
             return $this;
         } elseif (is_int($minInterval)) {
@@ -90,7 +84,7 @@ class RetryPolicy implements JsonSerializable
         return $this->useJitter;
     }
 
-    public function getRetryAt(int $retriesSoFar): ?DateTime
+    public function getRetryAt(int $retriesSoFar): ?DateTimeInterface
     {
         if ($retriesSoFar < $this->getMaxRetries()) {
             $interval = $this->getMinInterval() * ($this->getBackoffFactor() ** $retriesSoFar);
@@ -98,7 +92,7 @@ class RetryPolicy implements JsonSerializable
                 $jitterFactor = mt_rand(500, 1500) / 1000; // Jitter from 0.5 to 1.5 times the interval
                 $interval = round($interval * $jitterFactor);
             }
-            return (new DateTime())->modify("+$interval milliseconds");
+            return CarbonImmutable::now()->addMilliseconds((int) $interval);
         } else {
             return null;
         }

--- a/src/Task.php
+++ b/src/Task.php
@@ -2,13 +2,14 @@
 
 namespace Tsqm;
 
-use DateTime;
+use Carbon\CarbonImmutable;
+use DateTimeInterface;
 use JsonSerializable;
 use Tsqm\Errors\InvalidTask;
 
 class Task implements JsonSerializable
 {
-    private ?DateTime $scheduledFor = null;
+    private ?CarbonImmutable $scheduledFor = null;
 
     private ?string $waitInterval = null;
 
@@ -42,9 +43,9 @@ class Task implements JsonSerializable
         return $this;
     }
 
-    public function setScheduledFor(DateTime $scheduledFor): self
+    public function setScheduledFor(DateTimeInterface $scheduledFor): self
     {
-        $this->scheduledFor = $scheduledFor;
+        $this->scheduledFor = CarbonImmutable::instance($scheduledFor);
         return $this;
     }
 
@@ -53,7 +54,7 @@ class Task implements JsonSerializable
         return !is_null($this->scheduledFor);
     }
 
-    public function getScheduledFor(): ?DateTime
+    public function getScheduledFor(): ?DateTimeInterface
     {
         return $this->scheduledFor;
     }

--- a/src/TaskRepository.php
+++ b/src/TaskRepository.php
@@ -2,7 +2,8 @@
 
 namespace Tsqm;
 
-use DateTime;
+use Carbon\CarbonImmutable;
+use DateTimeInterface;
 use Exception;
 use PDO;
 use Tsqm\Errors\RepositoryError;
@@ -161,11 +162,11 @@ class TaskRepository
 
     /**
      * @param int $limit
-     * @param DateTime $now
+     * @param DateTimeInterface $now
      * @return array<PersistedTask>
      * @throws RepositoryError
      */
-    public function getScheduledTasks(int $limit, DateTime $now): array
+    public function getScheduledTasks(int $limit, DateTimeInterface $now): array
     {
         try {
             // MySQL strict mode fix
@@ -236,7 +237,7 @@ class TaskRepository
         }
     }
 
-    public function getLastFinishedAt(string $rootId): ?DateTime
+    public function getLastFinishedAt(string $rootId): ?DateTimeInterface
     {
         try {
             $res = $this->pdo->prepare("
@@ -257,7 +258,7 @@ class TaskRepository
             if (!$row || is_null($row['finished_at'])) {
                 return null;
             }
-            return new DateTime($row['finished_at']);
+            return CarbonImmutable::parse($row['finished_at']);
         } catch (Exception $e) {
             throw new RepositoryError("Failed to get last finished at: " . $e->getMessage(), 0, $e);
         }
@@ -300,16 +301,16 @@ class TaskRepository
             $ptask->setRootId($rootId);
         }
         if (isset($row['created_at'])) {
-            $ptask->setCreatedAt(new DateTime($row['created_at']));
+            $ptask->setCreatedAt(CarbonImmutable::parse($row['created_at']));
         }
         if (isset($row['scheduled_for'])) {
-            $ptask->setScheduledFor(new DateTime($row['scheduled_for']));
+            $ptask->setScheduledFor(CarbonImmutable::parse($row['scheduled_for']));
         }
         if (isset($row['started_at'])) {
-            $ptask->setStartedAt(new DateTime($row['started_at']));
+            $ptask->setStartedAt(CarbonImmutable::parse($row['started_at']));
         }
         if (isset($row['finished_at'])) {
-            $ptask->setFinishedAt(new DateTime($row['finished_at']));
+            $ptask->setFinishedAt(CarbonImmutable::parse($row['finished_at']));
         }
         if (isset($row['name'])) {
             $ptask->setName($row['name']);

--- a/src/Tsqm.php
+++ b/src/Tsqm.php
@@ -2,7 +2,8 @@
 
 namespace Tsqm;
 
-use DateTime;
+use Carbon\CarbonImmutable;
+use DateTimeInterface;
 use Exception;
 use Generator;
 use PDO;
@@ -99,7 +100,7 @@ class Tsqm implements TsqmInterface
         }
 
         if (!$this->options->isSyncRunsForced()) {
-            if ($async || $ptask->getScheduledFor() > new DateTime()) {
+            if ($async || $ptask->getScheduledFor() > CarbonImmutable::now()) {
                 $this->log(LogLevel::INFO, "Schedule {$ptask->getLogId()}", ['task' => $ptask]);
                 $this->enqueue($ptask);
                 return $ptask;
@@ -108,7 +109,7 @@ class Tsqm implements TsqmInterface
 
         $isStarted = $ptask->isStarted();
         if (!$isStarted) {
-            $ptask->setStartedAt(new DateTime());
+            $ptask->setStartedAt(CarbonImmutable::now());
         } else {
             $ptask->incRetried();
         }
@@ -184,7 +185,7 @@ class Tsqm implements TsqmInterface
             }
 
             $ptask
-                ->setFinishedAt(new DateTime())
+                ->setFinishedAt(CarbonImmutable::now())
                 ->setResult($result)
                 ->setError(null);
 
@@ -219,7 +220,7 @@ class Tsqm implements TsqmInterface
                 $this->enqueue($ptask);
             } else {
                 if (!$ptask->isFinished()) {
-                    $ptask->setFinishedAt(new DateTime());
+                    $ptask->setFinishedAt(CarbonImmutable::now());
                     $this->repository->updateTask($ptask);
                 }
 
@@ -246,18 +247,19 @@ class Tsqm implements TsqmInterface
             $ptask->setId($taskId);
         }
 
-        $ptask->setCreatedAt(new DateTime());
+        $ptask->setCreatedAt(CarbonImmutable::now());
 
         // Calculating scheduledFor if not set
         if (!$ptask->isScheduled()) {
             if ($ptask->hasWaitInterval()) {
                 $lastFinishedAt = $this->repository->getLastFinishedAt($ptask->getRootId());
-                if (is_null($lastFinishedAt)) {
-                    $lastFinishedAt = new DateTime();
-                }
-                $scheduledFor = $lastFinishedAt->modify($ptask->getWaitInterval());
-                if ($scheduledFor === false) {
-                    throw new InvalidWaitInterval("Invalid wait interval", 1720430537);
+                $lastFinishedAtCarbon = $lastFinishedAt
+                    ? CarbonImmutable::instance($lastFinishedAt)
+                    : CarbonImmutable::now();
+                try {
+                    $scheduledFor = $lastFinishedAtCarbon->modify($ptask->getWaitInterval());
+                } catch (\Exception $e) {
+                    throw new InvalidWaitInterval("Invalid wait interval", 1720430537, $e);
                 }
                 $ptask->setScheduledFor($scheduledFor);
             } else {
@@ -301,10 +303,10 @@ class Tsqm implements TsqmInterface
     /**
      * @return array<PersistedTask>
      */
-    public function list(int $limit = 100, ?DateTime $now = null): array
+    public function list(int $limit = 100, ?DateTimeInterface $now = null): array
     {
         if (is_null($now)) {
-            $now = new DateTime();
+            $now = CarbonImmutable::now();
         }
         return $this->repository->getScheduledTasks($limit, $now);
     }
@@ -332,7 +334,7 @@ class Tsqm implements TsqmInterface
             pcntl_signal(SIGQUIT, $signalHandler);
 
             while ($isListening) {
-                $now = (new DateTime())->modify("-$delay seconds");
+                $now = CarbonImmutable::now()->subSeconds($delay);
                 $tasks = $this->list($limit, $now);
                 if (count($tasks) > 0) {
                     foreach ($tasks as $task) {
@@ -385,8 +387,8 @@ class Tsqm implements TsqmInterface
 
             // Some queue implementations could operate at seconds resolution, but scheduledFor stored in microseconds.
             // So we need to add some leap-interval to prevent tasks to be delivered earlier than scheduledFor
-            $scheduledFor = (clone $ptask->getScheduledFor())
-                ->modify("+" . self::LEAP_INTERVAL . " seconds");
+            $scheduledFor = CarbonImmutable::instance($ptask->getScheduledFor())
+                ->addSeconds(self::LEAP_INTERVAL);
 
             // For child tasks we enqueue root tasks with the scheduledFor of child task
             // becasue TSQM suppose to run only root tasks

--- a/src/Tsqm.php
+++ b/src/Tsqm.php
@@ -258,7 +258,7 @@ class Tsqm implements TsqmInterface
                     : CarbonImmutable::now();
                 try {
                     $scheduledFor = $lastFinishedAtCarbon->modify($ptask->getWaitInterval());
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     throw new InvalidWaitInterval("Invalid wait interval", 1720430537, $e);
                 }
                 $ptask->setScheduledFor($scheduledFor);

--- a/src/TsqmInterface.php
+++ b/src/TsqmInterface.php
@@ -2,7 +2,7 @@
 
 namespace Tsqm;
 
-use DateTime;
+use DateTimeInterface;
 
 interface TsqmInterface
 {
@@ -24,10 +24,10 @@ interface TsqmInterface
     /**
      * Lists scheduled tasks.
      * @param int $limit
-     * @param DateTime|null $now
+     * @param DateTimeInterface|null $now
      * @return array<PersistedTask>
      */
-    public function list(int $limit = 100, ?DateTime $now = null): array;
+    public function list(int $limit = 100, ?DateTimeInterface $now = null): array;
 
     /**
      * Runs scheduled tasks in a polling mode.

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -2,7 +2,8 @@
 
 namespace Tests;
 
-use DateTime;
+use Carbon\CarbonImmutable;
+use DateTimeInterface;
 use Examples\Greeter\GreetNestedScheduled;
 use Examples\Greeter\GreetNestedWithFail;
 use Examples\Greeter\GreetScheduled;
@@ -46,8 +47,8 @@ class QueueTest extends TestCase
         $this->queue->expects($this->once())->method('enqueue')->with(
             $task->getName(),
             $this->callback(fn(string $taskId) => $this->assertUuid($taskId)),
-            $this->callback(fn(DateTime $scheduledFor) => $this->assertDateEquals(
-                (new DateTime())->modify('+1 second'),
+            $this->callback(fn(DateTimeInterface $scheduledFor) => $this->assertDateEquals(
+                (CarbonImmutable::now())->modify('+1 second'),
                 $scheduledFor,
                 50
             ))
@@ -59,7 +60,7 @@ class QueueTest extends TestCase
     public function testEnqueueScheduledTask(): void
     {
         $simpleGreet = $this->container->get(SimpleGreet::class);
-        $scheduledFor = (new DateTime())->modify('+1 day');
+        $scheduledFor = (CarbonImmutable::now())->modify('+1 day');
         $task = (new Task())
             ->setCallable($simpleGreet)
             ->setArgs('John Doe')
@@ -69,7 +70,7 @@ class QueueTest extends TestCase
             $task->getName(),
             $this->callback(fn(string $taskId) => $this->assertUuid($taskId)),
             $this->callback(
-                fn(DateTime $actualScheduledFor) => $this->assertDateEquals(
+                fn(DateTimeInterface $actualScheduledFor) => $this->assertDateEquals(
                     $scheduledFor->modify('+1 second'),
                     $actualScheduledFor
                 )
@@ -83,7 +84,7 @@ class QueueTest extends TestCase
     {
         $greetScheduled = $this->container->get(GreetScheduled::class);
 
-        $scheduledFor = (new DateTime())->modify('+1 day');
+        $scheduledFor = (CarbonImmutable::now())->modify('+1 day');
         $task = (new Task())
             ->setCallable($greetScheduled)
             ->setArgs('John Doe');
@@ -97,7 +98,7 @@ class QueueTest extends TestCase
                 return true;
             }),
             $this->callback(
-                fn(DateTime $actualScheduledFor) => $this->assertDateEquals(
+                fn(DateTimeInterface $actualScheduledFor) => $this->assertDateEquals(
                     $scheduledFor->modify('+1 second'),
                     $actualScheduledFor
                 )
@@ -168,8 +169,8 @@ class QueueTest extends TestCase
             $task->getName(),
             $this->callback(fn(string $taskId) => $this->assertUuid($taskId)),
             $this->callback(
-                fn(DateTime $actualScheduledFor) => $this->assertDateEquals(
-                    (new DateTime())->modify('+11 seconds'), // 10 seconds + leap second
+                fn(DateTimeInterface $actualScheduledFor) => $this->assertDateEquals(
+                    (CarbonImmutable::now())->modify('+11 seconds'), // 10 seconds + leap second
                     $actualScheduledFor
                 )
             )
@@ -182,7 +183,7 @@ class QueueTest extends TestCase
     {
         $simpleGreet = $this->container->get(SimpleGreet::class);
         $queue = [];
-        $now = new DateTime();
+        $now = CarbonImmutable::now();
 
         $task = (new Task())
             ->setCallable($simpleGreet)
@@ -192,7 +193,7 @@ class QueueTest extends TestCase
         $this->queue->expects($this->once())->method('enqueue')
             ->withAnyParameters()
             ->willReturnCallback(
-                function (string $taskName, string $taskId, DateTime $scheduledFor) use (&$queue, $now) {
+                function (string $taskName, string $taskId, DateTimeInterface $scheduledFor) use (&$queue, $now) {
                     $this->assertDateEquals($now->modify("+1 second"), $scheduledFor, 50);
                     if (!isset($queue[$taskName])) {
                         $queue[$taskName] = [];

--- a/tests/RetryPolicyTest.php
+++ b/tests/RetryPolicyTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use DateTime;
+use Carbon\CarbonImmutable;
 use Tsqm\RetryPolicy;
 
 class RetryPolicyTest extends TestCase
@@ -57,13 +57,13 @@ class RetryPolicyTest extends TestCase
         $retryPolicy->setMinInterval(300);
 
         $retryAt = $retryPolicy->getRetryAt(0);
-        $this->assertDateEquals((new DateTime())->modify('+300 milliseconds'), $retryAt);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+300 milliseconds'), $retryAt);
 
         $retryAt = $retryPolicy->getRetryAt(1);
-        $this->assertDateEquals((new DateTime())->modify('+300 milliseconds'), $retryAt);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+300 milliseconds'), $retryAt);
 
         $retryAt = $retryPolicy->getRetryAt(4);
-        $this->assertDateEquals((new DateTime())->modify('+300 milliseconds'), $retryAt);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+300 milliseconds'), $retryAt);
 
         $retryAt = $retryPolicy->getRetryAt(5);
         $this->assertNull($retryAt);
@@ -90,16 +90,16 @@ class RetryPolicyTest extends TestCase
         $retryPolicy->setBackoffFactor(2);
 
         $retryAt = $retryPolicy->getRetryAt(0);
-        $this->assertDateEquals((new DateTime())->modify('+300 milliseconds'), $retryAt);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+300 milliseconds'), $retryAt);
 
         $retryAt = $retryPolicy->getRetryAt(1);
-        $this->assertDateEquals((new DateTime())->modify('+600 milliseconds'), $retryAt);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+600 milliseconds'), $retryAt);
 
         $retryAt = $retryPolicy->getRetryAt(2);
-        $this->assertDateEquals((new DateTime())->modify('+1200 milliseconds'), $retryAt);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+1200 milliseconds'), $retryAt);
 
         $retryAt = $retryPolicy->getRetryAt(4);
-        $this->assertDateEquals((new DateTime())->modify('+4800 milliseconds'), $retryAt);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+4800 milliseconds'), $retryAt);
 
         $retryAt = $retryPolicy->getRetryAt(5);
         $this->assertNull($retryAt);
@@ -113,16 +113,16 @@ class RetryPolicyTest extends TestCase
         $retryPolicy->setBackoffFactor(1.2);
 
         $retryAt = $retryPolicy->getRetryAt(0);
-        $this->assertDateEquals((new DateTime())->modify('+300 milliseconds'), $retryAt);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+300 milliseconds'), $retryAt);
 
         $retryAt = $retryPolicy->getRetryAt(1);
-        $this->assertDateEquals((new DateTime())->modify('+360 milliseconds'), $retryAt);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+360 milliseconds'), $retryAt);
 
         $retryAt = $retryPolicy->getRetryAt(2);
-        $this->assertDateEquals((new DateTime())->modify('+432 milliseconds'), $retryAt);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+432 milliseconds'), $retryAt);
 
         $retryAt = $retryPolicy->getRetryAt(4);
-        $this->assertDateEquals((new DateTime())->modify('+622 milliseconds'), $retryAt, 1000);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+622 milliseconds'), $retryAt, 1000);
 
         $retryAt = $retryPolicy->getRetryAt(5);
         $this->assertNull($retryAt);
@@ -136,13 +136,13 @@ class RetryPolicyTest extends TestCase
             ->setUseJitter(true);
 
         $retryAt = $retryPolicy->getRetryAt(0);
-        $this->assertDateEquals((new DateTime())->modify('+300 milliseconds'), $retryAt, 160);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+300 milliseconds'), $retryAt, 160);
 
         $retryAt = $retryPolicy->getRetryAt(1);
-        $this->assertDateEquals((new DateTime())->modify('+300 milliseconds'), $retryAt, 160);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+300 milliseconds'), $retryAt, 160);
 
         $retryAt = $retryPolicy->getRetryAt(4);
-        $this->assertDateEquals((new DateTime())->modify('+300 milliseconds'), $retryAt, 160);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+300 milliseconds'), $retryAt, 160);
 
         $retryAt = $retryPolicy->getRetryAt(5);
         $this->assertNull($retryAt);
@@ -157,13 +157,13 @@ class RetryPolicyTest extends TestCase
             ->setUseJitter(true);
 
         $retryAt = $retryPolicy->getRetryAt(0);
-        $this->assertDateEquals((new DateTime())->modify('+300 milliseconds'), $retryAt, 160);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+300 milliseconds'), $retryAt, 160);
 
         $retryAt = $retryPolicy->getRetryAt(1);
-        $this->assertDateEquals((new DateTime())->modify('+600 milliseconds'), $retryAt, 310);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+600 milliseconds'), $retryAt, 310);
 
         $retryAt = $retryPolicy->getRetryAt(4);
-        $this->assertDateEquals((new DateTime())->modify('+4800 milliseconds'), $retryAt, 2410);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+4800 milliseconds'), $retryAt, 2410);
 
         $retryAt = $retryPolicy->getRetryAt(5);
         $this->assertNull($retryAt);

--- a/tests/SchedulerTest.php
+++ b/tests/SchedulerTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests;
 
+use Carbon\CarbonImmutable;
 use Closure;
-use DateTime;
 use Examples\Greeter\GreetWithPurchaseFailAndRetryInterval;
 use Examples\Greeter\SimpleGreet;
 use Examples\Greeter\SimpleGreetWith3Fails;
@@ -25,7 +25,7 @@ class SchedulerTest extends TestCase
             ->setArgs('John Doe');
 
         $task = $this->tsqm->run($task);
-        $this->assertDateEquals($task->getScheduledFor(), new DateTime(), 50);
+        $this->assertDateEquals($task->getScheduledFor(), CarbonImmutable::now(), 50);
         $this->assertTrue($task->isFinished());
     }
 
@@ -37,7 +37,7 @@ class SchedulerTest extends TestCase
             ->setArgs('John Doe');
 
         $task = $this->tsqm->run($task, true);
-        $this->assertDateEquals($task->getScheduledFor(), new DateTime(), 50);
+        $this->assertDateEquals($task->getScheduledFor(), CarbonImmutable::now(), 50);
         $this->assertFalse($task->isFinished());
     }
 
@@ -56,7 +56,7 @@ class SchedulerTest extends TestCase
             ->setArgs('John Doe');
 
         $task = $tsqm->run($task, true);
-        $this->assertDateEquals($task->getStartedAt(), new DateTime(), 50);
+        $this->assertDateEquals($task->getStartedAt(), CarbonImmutable::now(), 50);
         $this->assertNotNull($task->getResult());
         $this->assertTrue($task->isFinished());
     }
@@ -74,10 +74,10 @@ class SchedulerTest extends TestCase
         $task = (new Task())
             ->setCallable($simpleGreet)
             ->setArgs('John Doe')
-            ->setScheduledFor((new DateTime())->modify('+1 day'));
+            ->setScheduledFor((CarbonImmutable::now())->modify('+1 day'));
 
         $task = $tsqm->run($task);
-        $this->assertDateEquals($task->getStartedAt(), new DateTime(), 50);
+        $this->assertDateEquals($task->getStartedAt(), CarbonImmutable::now(), 50);
         $this->assertNotNull($task->getResult());
         $this->assertTrue($task->isFinished());
     }
@@ -85,7 +85,7 @@ class SchedulerTest extends TestCase
     public function testScheduledFor(): void
     {
         $simpleGreet = $this->container->get(SimpleGreet::class);
-        $scheduleFor = (new DateTime())->modify('+1 day');
+        $scheduleFor = (CarbonImmutable::now())->modify('+1 day');
 
         $task = (new Task())
             ->setCallable($simpleGreet)
@@ -114,7 +114,7 @@ class SchedulerTest extends TestCase
 
         $this->assertDateEquals(
             $task->getScheduledFor(),
-            (new DateTime())->modify('+1500 milliseconds')
+            (CarbonImmutable::now())->modify('+1500 milliseconds')
         );
         $this->assertFalse($task->isFinished());
     }
@@ -132,7 +132,7 @@ class SchedulerTest extends TestCase
     public function testListScheduledTasks(): void
     {
         $simpleGreetWith3Fails = $this->container->get(SimpleGreetWith3Fails::class);
-        $scheduledFor = (new DateTime())->modify('+10 second');
+        $scheduledFor = (CarbonImmutable::now())->modify('+10 second');
         $task = (new Task())
             ->setCallable($simpleGreetWith3Fails)
             ->setArgs('John Doe')
@@ -162,14 +162,14 @@ class SchedulerTest extends TestCase
         $this->tsqm->run($task);
         $this->tsqm->run($task);
 
-        $scheduledTasks = $this->tsqm->list(10, (new DateTime())->modify("-10 second"));
+        $scheduledTasks = $this->tsqm->list(10, (CarbonImmutable::now())->modify("-10 second"));
         $this->assertCount(0, $scheduledTasks);
     }
 
     public function testListScheduledTasksLimit(): void
     {
         $simpleGreetWith3Fails = $this->container->get(SimpleGreetWith3Fails::class);
-        $scheduledFor = (new DateTime())->modify('+10 second');
+        $scheduledFor = (CarbonImmutable::now())->modify('+10 second');
         $task = (new Task())
             ->setCallable($simpleGreetWith3Fails)
             ->setArgs('John Doe')
@@ -206,10 +206,10 @@ class SchedulerTest extends TestCase
         $simpleGreet = $this->container->get(SimpleGreet::class);
 
         $cases = [
-            '10 second' => (new DateTime())->modify('+10 second'),
-            '+10 second' => (new DateTime())->modify('+10 second'),
-            '-10 second' => (new DateTime())->modify('-10 second'),
-            '1 day' => (new DateTime())->modify('+1 day'),
+            '10 second' => (CarbonImmutable::now())->modify('+10 second'),
+            '+10 second' => (CarbonImmutable::now())->modify('+10 second'),
+            '-10 second' => (CarbonImmutable::now())->modify('-10 second'),
+            '1 day' => (CarbonImmutable::now())->modify('+1 day'),
         ];
 
         foreach ($cases as $waitInterval => $expectedScheduledFor) {
@@ -242,6 +242,6 @@ class SchedulerTest extends TestCase
         $lastTask = $this->getLastTaskByParentId($task->getId());
         $this->assertNotNull($lastTask);
         $this->assertFalse($lastTask->isFinished());
-        $this->assertDateEquals((new DateTime())->modify('+1 day'), $lastTask->getScheduledFor(), 50);
+        $this->assertDateEquals((CarbonImmutable::now())->modify('+1 day'), $lastTask->getScheduledFor(), 50);
     }
 }

--- a/tests/SerializationTest.php
+++ b/tests/SerializationTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use DateTime;
+use Carbon\CarbonImmutable;
 use Exception;
 use PDOException;
 use Examples\Greeter\GreeterError;
@@ -28,8 +28,8 @@ class SerializationTest extends TestCase
         $ptask = (new PersistedTask())
             ->setId($taskId)
             ->setRootId($taskId)
-            ->setCreatedAt(new DateTime())
-            ->setScheduledFor(new DateTime())
+            ->setCreatedAt(CarbonImmutable::now())
+            ->setScheduledFor(CarbonImmutable::now())
             ->setName("Random task name");
         $ptask = $repository->createTask($ptask);
 

--- a/tests/SmokeTest.php
+++ b/tests/SmokeTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use DateTime;
+use Carbon\CarbonImmutable;
 use Examples\Greeter\Greet;
 use Examples\Greeter\GreetNested;
 use Examples\Greeter\SimpleGreet;
@@ -23,7 +23,7 @@ class SmokeTest extends TestCase
 
         $task = $this->tsqm->run($task);
 
-        $now = new DateTime();
+        $now = CarbonImmutable::now();
 
         $this->assertUuid($task->getId());
         $this->assertNull($task->getParentId());

--- a/tests/TaskFlowTest.php
+++ b/tests/TaskFlowTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use DateTime;
+use Carbon\CarbonImmutable;
 use Examples\Greeter\GreeterError;
 use Examples\Greeter\SimpleGreet;
 use Examples\Greeter\SimpleGreetWith3Fails;
@@ -23,7 +23,7 @@ class TaskFlowTest extends TestCase
 
         $task = $this->tsqm->run($task);
 
-        $now = new DateTime();
+        $now = CarbonImmutable::now();
 
         $this->assertDateEquals($task->getFinishedAt(), $now);
 
@@ -55,7 +55,7 @@ class TaskFlowTest extends TestCase
             ->setCallable($simpleGreet)
             ->setArgs('John Doe');
 
-        $now = new DateTime();
+        $now = CarbonImmutable::now();
 
         $task = $this->tsqm->run($task);
 
@@ -85,11 +85,11 @@ class TaskFlowTest extends TestCase
         $task = (new Task())
             ->setCallable($simpleGreet)
             ->setArgs('John Doe')
-            ->setScheduledFor((new DateTime())->modify("+10 second"));
+            ->setScheduledFor((CarbonImmutable::now())->modify("+10 second"));
 
         $task = $this->tsqm->run($task);
 
-        $scheduledFor = (new DateTime())->modify("+10 second");
+        $scheduledFor = (CarbonImmutable::now())->modify("+10 second");
 
         $this->assertDateEquals($task->getScheduledFor(), $scheduledFor);
         $this->assertNull($task->getFinishedAt());
@@ -103,11 +103,11 @@ class TaskFlowTest extends TestCase
         $task = (new Task())
             ->setCallable($simpleGreet)
             ->setArgs('John Doe')
-            ->setScheduledFor((new DateTime())->modify("+10 second"));
+            ->setScheduledFor((CarbonImmutable::now())->modify("+10 second"));
 
         $task = $this->tsqm->run($task);
 
-        $scheduledFor = (new DateTime())->modify("+10 second");
+        $scheduledFor = (CarbonImmutable::now())->modify("+10 second");
 
         $this->assertDateEquals($task->getScheduledFor(), $scheduledFor);
         $this->assertNull($task->getFinishedAt());
@@ -130,11 +130,11 @@ class TaskFlowTest extends TestCase
         $task = (new Task())
             ->setCallable($simpleGreetWithFail)
             ->setArgs('John Doe')
-            ->setScheduledFor((new DateTime())->modify("+10 second"));
+            ->setScheduledFor((CarbonImmutable::now())->modify("+10 second"));
 
         $task = $this->tsqm->run($task);
 
-        $scheduledFor = (new DateTime())->modify("+10 second");
+        $scheduledFor = (CarbonImmutable::now())->modify("+10 second");
 
         $this->assertDateEquals($task->getScheduledFor(), $scheduledFor);
         $this->assertNull($task->getFinishedAt());
@@ -152,7 +152,7 @@ class TaskFlowTest extends TestCase
 
         $task = $this->tsqm->run($task);
 
-        $now = new DateTime();
+        $now = CarbonImmutable::now();
 
         $this->assertDateEquals($task->getFinishedAt(), $now);
         $this->assertInstanceOf(GreeterError::class, $task->getError());
@@ -184,7 +184,7 @@ class TaskFlowTest extends TestCase
 
         $task = $this->tsqm->run($task);
 
-        $now = new DateTime();
+        $now = CarbonImmutable::now();
 
         $this->assertDateEquals($task->getFinishedAt(), $now);
         $this->assertEquals(new GreeterError("Greet John Doe failed", 1717414866), $task->getError());
@@ -214,7 +214,7 @@ class TaskFlowTest extends TestCase
 
         $task = $this->tsqm->run($task);
 
-        $scheduledFor = (new DateTime())->modify("+10 second");
+        $scheduledFor = (CarbonImmutable::now())->modify("+10 second");
 
         $this->assertDateEquals($task->getScheduledFor(), $scheduledFor);
         $this->assertNull($task->getFinishedAt());

--- a/tests/TaskGeneratorFlowTest.php
+++ b/tests/TaskGeneratorFlowTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use DateTime;
+use Carbon\CarbonImmutable;
 use Examples\Greeter\CreateGreeting;
 use Examples\Greeter\Greet;
 use Examples\Greeter\GreeterError;
@@ -34,7 +34,7 @@ class TaskGeneratorFlowTest extends TestCase
 
         $task = $this->tsqm->run($task);
 
-        $now = new DateTime();
+        $now = CarbonImmutable::now();
 
         $this->assertDateEquals($task->getFinishedAt(), $now);
         $this->assertEquals("Hello, John Doe!", $task->getResult()->getText());
@@ -52,7 +52,7 @@ class TaskGeneratorFlowTest extends TestCase
             ->setArgs('John Doe');
 
         $task = $this->tsqm->run($task);
-        $now = new DateTime();
+        $now = CarbonImmutable::now();
 
         for ($i = 0; $i < 3; $i++) {
             $task = $this->tsqm->run($task);
@@ -74,7 +74,7 @@ class TaskGeneratorFlowTest extends TestCase
             ->setArgs('John Doe');
 
         $task = $this->tsqm->run($task);
-        $now = new DateTime();
+        $now = CarbonImmutable::now();
 
         $this->assertDateEquals($task->getFinishedAt(), $now);
         $this->assertNull($task->getResult());
@@ -92,7 +92,7 @@ class TaskGeneratorFlowTest extends TestCase
             ->setArgs('John Doe');
 
         $task = $this->tsqm->run($task);
-        $now = new DateTime();
+        $now = CarbonImmutable::now();
 
         $this->assertDateEquals($task->getFinishedAt(), $now);
         $this->assertNull($task->getResult());
@@ -122,7 +122,7 @@ class TaskGeneratorFlowTest extends TestCase
 
         $task = $this->tsqm->run($task);
 
-        $sheduledFor = (new DateTime())->modify("+10 second");
+        $sheduledFor = (CarbonImmutable::now())->modify("+10 second");
 
         $this->assertNull($task->getFinishedAt());
         $this->assertDateEquals($task->getScheduledFor(), $sheduledFor);
@@ -158,7 +158,7 @@ class TaskGeneratorFlowTest extends TestCase
         // Last success retry
         $task = $this->tsqm->get($task->getRootId());
         $task = $this->tsqm->run($task);
-        $this->assertDateEquals($task->getFinishedAt(), new DateTime());
+        $this->assertDateEquals($task->getFinishedAt(), CarbonImmutable::now());
 
         $this->assertEquals("Hello, John Doe!", $task->getResult()->getText());
         $this->assertTrue($task->getResult()->getSent());
@@ -189,7 +189,7 @@ class TaskGeneratorFlowTest extends TestCase
         // Last failed retry
         $task = $this->tsqm->get($task->getRootId());
         $task = $this->tsqm->run($task);
-        $this->assertDateEquals($task->getFinishedAt(), new DateTime());
+        $this->assertDateEquals($task->getFinishedAt(), CarbonImmutable::now());
         $this->assertNull($task->getResult());
         $this->assertEquals(
             new GreeterError("Purchase failed", 1700410299),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use DateTime;
+use DateTimeInterface;
 use DI\Container;
 use Examples\Helpers\DbHelper;
 use Examples\PsrContainer;
@@ -39,8 +39,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
     }
 
     public function assertDateEquals(
-        DateTime $expected,
-        DateTime $actual,
+        DateTimeInterface $expected,
+        DateTimeInterface $actual,
         int $deltaMs = 50,
         string $message = ''
     ): bool {
@@ -48,7 +48,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $this->assertLessThanOrEqual(
             $deltaMs,
             $diff,
-            "Failed asserting that two DateTime instances are equal with $deltaMs ms delta."
+            "Failed asserting that two dates are equal with $deltaMs ms delta."
                 . ($message ? " $message" : "")
         );
         return $diff <= $deltaMs;


### PR DESCRIPTION
## Summary
- Add `nesbot/carbon` ^3.11 dependency and replace all `DateTime` usage with `CarbonImmutable`
- Use `DateTimeInterface` in public API signatures for interoperability, convert to `CarbonImmutable` internally
- Simplify `RetryPolicy::setMinInterval` by replacing manual `microtime()` parsing with Carbon's fluent API
- Update pre-commit hook to use `make check` (runs in Docker)

## Test plan
- [x] All 78 tests pass (PHP 8.2 in Docker)
- [x] PHP CS Fixer clean
- [ ] Verify no downstream code depends on concrete `DateTime` return types